### PR TITLE
fix: 安卓端用media_kit解码32bit flac

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -221,10 +221,10 @@ void main(List<String> args) async {
     return;
   }
 
-  // Initialize just_audio_media_kit for desktop platforms
-  if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
+  // Initialize just_audio_media_kit for desktop and Android platforms
+  if (Platform.isWindows || Platform.isLinux || Platform.isMacOS || Platform.isAndroid) {
     await _configureMpv();
-    JustAudioMediaKit.ensureInitialized();
+    JustAudioMediaKit.ensureInitialized(android: true);
   }
 
   if (Platform.isWindows || Platform.isLinux) {

--- a/lib/src/utils/theme.dart
+++ b/lib/src/utils/theme.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import '../providers/theme_provider.dart';
+import 'package:flutter/cupertino.dart';
 
 class AppTheme {
   // iOS 使用 Cupertino 转场以支持侧滑返回

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   media_kit: ^1.2.0
   media_kit_libs_windows_audio: ^1.0.9
   media_kit_libs_linux: ^1.1.5
+  media_kit_libs_android_audio: ^1.1.5
   audio_service: ^0.18.12
   smtc_windows: ^0.1.3
   flutter_pdfview: ^1.3.2


### PR DESCRIPTION
修改内容
1. 在pubspec.yaml中补充media_kit_libs_android_audio依赖。
2. 将Platform.isAndroid加入到JustAudioMediaKit的初始化条件中，绕过ExoPlayer。
3. 修复新版Flutter缺失cupertino引用的报错。

修改原因
原版安卓端依赖just_audio走系统的ExoPlayer，导致无法解码32bit FLAC音频。

测试情况
APK云端打包成功，实测可以播放32bit FLAC。